### PR TITLE
fix: add missing "basic" client scope

### DIFF
--- a/compose/openems-dev/keycloak/config/oce.json
+++ b/compose/openems-dev/keycloak/config/oce.json
@@ -28,11 +28,11 @@
       },
       "webOrigins": ["*"],
       "defaultClientScopes": [
-        "basic",
         "web-origins",
         "acr",
         "profile",
         "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [

--- a/compose/openems-dev/keycloak/config/oce.json
+++ b/compose/openems-dev/keycloak/config/oce.json
@@ -28,6 +28,7 @@
       },
       "webOrigins": ["*"],
       "defaultClientScopes": [
+        "basic",
         "web-origins",
         "acr",
         "profile",

--- a/devops/templates/keycloak/config/oce.json
+++ b/devops/templates/keycloak/config/oce.json
@@ -44,6 +44,7 @@
       },
       "webOrigins": ["*"],
       "defaultClientScopes": [
+        "basic",
         "web-origins",
         "acr",
         "profile",

--- a/devops/templates/keycloak/config/oce.json
+++ b/devops/templates/keycloak/config/oce.json
@@ -44,11 +44,11 @@
       },
       "webOrigins": ["*"],
       "defaultClientScopes": [
-        "basic",
         "web-origins",
         "acr",
         "profile",
         "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [

--- a/devops/templates/keycloak/config/oce.json
+++ b/devops/templates/keycloak/config/oce.json
@@ -44,11 +44,11 @@
       },
       "webOrigins": ["*"],
       "defaultClientScopes": [
+        "basic",
         "web-origins",
         "acr",
         "profile",
         "roles",
-        "basic",
         "email"
       ],
       "optionalClientScopes": [


### PR DESCRIPTION
References:
-  https://www.keycloak.org/docs/latest/upgrading/index.html#sub-claim-is-added-to-access-token-via-protocol-mapper
- https://github.com/keycloak/keycloak/issues/31082